### PR TITLE
CLI Time arguments

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -29,7 +29,7 @@ pub const SND_REFINE_CD_R_STEPS: (f32, f32) = (f32::to_radians(0.5), f32::to_rad
 pub const UNIQUE_SAMPLE_THRESHOLD: f32 = 0.05;
 
 pub const DEFAULT_EXPLORE_TIME_RATIO: f32 = 0.8;
-pub const DEFAULT_COMPRESS_TIME_RATIO: f32 = 1.0 - 0.2;
+pub const DEFAULT_COMPRESS_TIME_RATIO: f32 = 0.2;
 
 pub const DEFAULT_MAX_CONSEQ_FAILS_EXPL: usize = 10;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ fn main() -> Result<()>{
         },
         _ => bail!("invalid cli pattern (clap should have caught this)"),
     };
+    config.expl_cfg.time_limit = explore_dur;
+    config.cmpr_cfg.time_limit = compress_dur;
     if args.early_termination {
         config.expl_cfg.max_conseq_failed_attempts = Some(DEFAULT_MAX_CONSEQ_FAILS_EXPL);
         config.cmpr_cfg.shrink_decay = ShrinkDecayStrategy::FailureBased(DEFAULT_FAIL_DECAY_RATIO_CMPR);


### PR DESCRIPTION
Hello, 

When testing spyrrow, I noticed that when you refactored the way your cli code works, the time given by the cli were not taken into account anymore.
The ratios of Exploration Time and Compression Time didn't add to 1 either. 
So I propose this simple fix in order to make the cli behave the way one would expect.

Paul Durand-Lupinski