### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     //the input file is the first argument
     let input_file_path = args().nth(1).expect("first argument must be the input file");
     let time_limit: Duration = args().nth(2).expect("second argument must be the time limit [s]")
-        .parse::<u64>().map(|s| Duration::from_secs(s))
+        .parse::<u64>().map(Duration::from_secs)
         .expect("second argument must be the time limit [s]");
     let n_runs_total = args().nth(3).expect("third argument must be the number of runs")
         .parse().expect("third argument must be the number of runs");
@@ -107,10 +107,10 @@ fn main() -> Result<()> {
                     );
 
                     io::write_svg(
-                        &s_layout_to_svg(&cmpr_sol.layout_snapshot, &instance, DRAW_OPTIONS, &*format!("final_bench_{}", bench_idx)),
+                        &s_layout_to_svg(&cmpr_sol.layout_snapshot, &instance, DRAW_OPTIONS, &format!("final_bench_{}", bench_idx)),
                         Path::new(&format!("{OUTPUT_DIR}/final_bench_{}.svg", bench_idx)),
                         log::Level::Info,
-                    ).expect(&*format!("could not write svg output of bench {}", bench_idx));
+                    ).unwrap_or_else(|_| panic!("could not write svg output of bench {}", bench_idx));
 
                     *sol_slice = Some(cmpr_sol);
                 })
@@ -169,7 +169,7 @@ pub fn calculate_percentile(v: &[f32], pct: f32) -> f32 {
     // Validate input
     assert!(!v.is_empty(), "Cannot compute percentile of an empty slice");
     assert!(
-        pct >= 0.0 && pct <= 1.0,
+        (0.0..=1.0).contains(&pct),
         "Percent must be between 0.0 and 1.0"
     );
 
@@ -210,7 +210,7 @@ pub fn calculate_stddev(v: &[f32]) -> f32 {
 
 pub fn get_git_commit_hash() -> String {
     let output = std::process::Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("Failed to execute git command");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,7 @@ pub const DEFAULT_SPARROW_CONFIG: SparrowConfig = SparrowConfig {
     },
     cmpr_cfg: CompressionConfig {
         shrink_range: (0.0005, 0.00001),
-        time_limit: Duration::from_secs(1 * 60),
+        time_limit: Duration::from_secs(60),
         shrink_decay: ShrinkDecayStrategy::TimeBased,
         separator_config: SeparatorConfig {
             iter_no_imprv_limit: 100,

--- a/src/optimizer/compress.rs
+++ b/src/optimizer/compress.rs
@@ -54,7 +54,7 @@ pub fn compression_phase(
 fn attempt_to_compress(sep: &mut Separator, init: &SPSolution, r_shrink: f32, term: &impl Terminator, sol_listener: &mut impl SolutionListener) -> Option<SPSolution> {
     //restore to the initial solution and width
     sep.change_strip_width(init.strip_width(), None);
-    sep.rollback(&init, None);
+    sep.rollback(init, None);
 
     //shrink the container at a random position
     let new_width = init.strip_width() * (1.0 - r_shrink);

--- a/src/optimizer/lbf.rs
+++ b/src/optimizer/lbf.rs
@@ -45,11 +45,10 @@ impl LBFBuilder {
                 let diameter = item_shape.diameter;
                 Reverse(OrderedFloat(convex_hull_area * diameter))
             })
-            .map(|id| {
+            .flat_map(|id| {
                 let missing_qty = self.prob.item_demand_qtys[id];
-                iter::repeat(id).take(missing_qty)
+                iter::repeat_n(id, missing_qty)
             })
-            .flatten()
             .collect_vec();
 
         debug!("[CONSTR] placing items in order: {:?}",sorted_item_indices);

--- a/src/optimizer/separator.rs
+++ b/src/optimizer/separator.rs
@@ -46,7 +46,7 @@ impl Separator {
                 prob: prob.clone(),
                 ct: ct.clone(),
                 rng: Xoshiro256PlusPlus::seed_from_u64(rng.random()),
-                sample_config: config.sample_config.clone(),
+                sample_config: config.sample_config,
             }).collect();
 
         let pool = if cfg!(target_arch = "wasm32") {
@@ -156,7 +156,7 @@ impl Separator {
         };
 
         let sep_report = match self.thread_pool.as_mut() {
-            Some(pool) => pool.install(|| separate_multi()),
+            Some(pool) => pool.install(&mut separate_multi),
             None => separate_multi(),
         };
 
@@ -247,7 +247,7 @@ impl Separator {
                 prob: self.prob.clone(),
                 ct: self.ct.clone(),
                 rng: Xoshiro256PlusPlus::seed_from_u64(self.rng.random()),
-                sample_config: self.config.sample_config.clone(),
+                sample_config: self.config.sample_config,
             };
         });
         debug!("[SEP] changed strip width to {:.3}", new_width);

--- a/src/quantify/mod.rs
+++ b/src/quantify/mod.rs
@@ -15,7 +15,7 @@ pub mod simd;
 pub fn quantify_collision_poly_poly(s1: &SPolygon, s2: &SPolygon) -> f32 {
     let epsilon = f32::max(s1.diameter, s2.diameter) * OVERLAP_PROXY_EPSILON_DIAM_RATIO;
 
-    let overlap_proxy = overlap_area_proxy(&s1.surrogate(), &s2.surrogate(), epsilon) + epsilon.powi(2);
+    let overlap_proxy = overlap_area_proxy(s1.surrogate(), s2.surrogate(), epsilon) + epsilon.powi(2);
 
     debug_assert!(overlap_proxy.is_normal());
 
@@ -37,8 +37,8 @@ pub fn quantify_collision_poly_container(s: &SPolygon, c_bbox: Rect) -> f32 {
     let overlap = match Rect::intersection(s_bbox, c_bbox) {
         Some(r) => {
             //intersection exist, calculate the area of the intersection (+ a small value to ensure it is never zero)
-            let negative_area = (s_bbox.area() - r.area()) + 0.0001 * s_bbox.area();
-            negative_area
+            
+            (s_bbox.area() - r.area()) + 0.0001 * s_bbox.area()
         }
         None => {
             //no intersection, guide towards intersection with container

--- a/src/quantify/overlap_proxy.rs
+++ b/src/quantify/overlap_proxy.rs
@@ -5,7 +5,7 @@ use jagua_rs::geometry::geo_traits::DistanceTo;
 /// Calculates a proxy for the overlap area between two simple polygons (using poles).
 /// Algorithm 3 from https://doi.org/10.48550/arXiv.2509.13329
 #[inline(always)]
-pub fn overlap_area_proxy<'a>(sp1: &SPSurrogate, sp2: &SPSurrogate, epsilon: f32) -> f32 {
+pub fn overlap_area_proxy(sp1: &SPSurrogate, sp2: &SPSurrogate, epsilon: f32) -> f32 {
     let mut total_overlap = 0.0;
     for p1 in &sp1.poles {
         for p2 in &sp2.poles {

--- a/src/sample/search.rs
+++ b/src/sample/search.rs
@@ -50,7 +50,7 @@ pub fn search_placement(l: &Layout, item: &Item, ref_pk: Option<PItemKey>, mut e
 
     if let Some(container_sampler) = container_sampler {
         for _ in 0..sample_config.n_container_samples {
-            let dt = container_sampler.sample(rng).into();
+            let dt = container_sampler.sample(rng);
             let eval = evaluator.evaluate_sample(dt, Some(best_samples.upper_bound()));
             best_samples.report(dt, eval);
         }
@@ -59,7 +59,7 @@ pub fn search_placement(l: &Layout, item: &Item, ref_pk: Option<PItemKey>, mut e
     //Prerefine the best samples
     for start in best_samples.samples.clone() {
         let descended = refine_coord_desc(
-            start.clone(),
+            start,
             &mut evaluator,
             prerefine_cd_config(item),
             rng,

--- a/src/sample/uniform_sampler.rs
+++ b/src/sample/uniform_sampler.rs
@@ -46,7 +46,7 @@ impl UniformBBoxSampler {
         // for each possible rotation, calculate the sample ranges (x and y)
         // where the item resides fully inside the container and is within the sample bounding box
         let rot_entries = rotations.iter()
-            .map(|&r| {
+            .filter_map(|&r| {
                 let r_shape_bbox = shape_buffer.transform_from(item.shape_cd.as_ref(), &Transformation::from_rotation(r)).bbox;
 
                 //narrow the container range to account for the rotated shape
@@ -63,7 +63,7 @@ impl UniformBBoxSampler {
                 } else {
                     Some(RotEntry { r, x_range, y_range })
                 }
-            }).flatten().collect_vec();
+            }).collect_vec();
 
         match rot_entries.is_empty() {
             true => None,

--- a/src/util/ctrlc_terminator.rs
+++ b/src/util/ctrlc_terminator.rs
@@ -11,6 +11,12 @@ pub struct CtrlCTerminator {
     pub ctrlc: Arc<AtomicBool>,
 }
 
+impl Default for CtrlCTerminator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CtrlCTerminator {
     /// Sets up the handler for Ctrl-C (only call once)
     pub fn new() -> Self {
@@ -31,7 +37,7 @@ impl CtrlCTerminator {
 
 impl Terminator for CtrlCTerminator {
     fn kill(&self) -> bool {
-        self.timeout.map_or(false, |timeout| Instant::now() > timeout)
+        self.timeout.is_some_and(|timeout| Instant::now() > timeout)
             || self.ctrlc.load(Ordering::SeqCst)
     }
 

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -76,7 +76,7 @@ pub fn init_logger(level_filter: LevelFilter, log_file_path: &Path) -> Result<()
     log!(
         Level::Info,
         "[EPOCH]: {}",
-        jiff::Timestamp::now().to_string()
+        jiff::Timestamp::now()
     );
     Ok(())
 }
@@ -90,7 +90,7 @@ pub fn write_svg(document: &Document, path: &Path, log_lvl: Level) -> Result<()>
     svg::save(path, document)?;
     log!(log_lvl,
         "[IO] svg exported to file://{}",
-        fs::canonicalize(&path)
+        fs::canonicalize(path)
             .expect("could not canonicalize path")
             .to_str()
             .unwrap()
@@ -103,7 +103,7 @@ pub fn write_json(json: &impl Serialize, path: &Path, log_lvl: Level) -> Result<
     serde_json::to_writer_pretty(file, json)?;
     log!(log_lvl,
         "[IO] json exported to file://{}",
-        fs::canonicalize(&path)
+        fs::canonicalize(path)
             .expect("could not canonicalize path")
             .to_str()
             .unwrap()

--- a/src/util/svg_exporter.rs
+++ b/src/util/svg_exporter.rs
@@ -18,15 +18,14 @@ pub struct SvgExporter {
 impl SvgExporter {
     pub fn new(final_path: Option<String>, intermediate_dir: Option<String>, live_path: Option<String>) -> Self {
         // Clean all svg files from the intermediate directory if it is provided
-        if let Some(intermediate_dir) = &intermediate_dir {
-            if let Ok(files_in_dir) = std::fs::read_dir(&Path::new(intermediate_dir)) {
+        if let Some(intermediate_dir) = &intermediate_dir
+            && let Ok(files_in_dir) = std::fs::read_dir(Path::new(intermediate_dir)) {
                 for file in files_in_dir.flatten() {
                     if file.path().extension().unwrap_or_default() == "svg" {
                         std::fs::remove_file(file.path()).unwrap();
                     }
                 }
             }
-        }
         
         SvgExporter {
             svg_counter: 0,
@@ -48,7 +47,7 @@ impl SolutionListener for SvgExporter{
         };
         let file_name = format!("{}_{:.3}_{}", self.svg_counter, solution.strip_width(), suffix);
         if let Some(live_path) = &self.live_path {
-            let svg = s_layout_to_svg(&solution.layout_snapshot, instance, DRAW_OPTIONS, &file_name.as_str());
+            let svg = s_layout_to_svg(&solution.layout_snapshot, instance, DRAW_OPTIONS, file_name.as_str());
             io::write_svg(&svg, Path::new(live_path), Level::Trace).expect("failed to write live svg");
         }
         if let Some(intermediate_dir) = &self.intermediate_dir && report_type != ReportType::ExplImproving {

--- a/src/util/terminator.rs
+++ b/src/util/terminator.rs
@@ -18,6 +18,12 @@ pub struct BasicTerminator {
     pub timeout: Option<Instant>,
 }
 
+impl Default for BasicTerminator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BasicTerminator {
     pub fn new() -> Self {
         Self { timeout: None }
@@ -26,7 +32,7 @@ impl BasicTerminator {
 
 impl Terminator for BasicTerminator {
     fn kill(&self) -> bool {
-        self.timeout.map_or(false, |timeout| Instant::now() > timeout)
+        self.timeout.is_some_and(|timeout| Instant::now() > timeout)
     }
 
     fn new_timeout(&mut self, timeout: Duration){


### PR DESCRIPTION
Currently, running `cargo clippy` on the main branch generates 30 warnings (24 from the `sparrow` lib and 6 from the `bench` binary).

This PR applies automatic fixes proposed by clippy and manually implements the changes required to fix the remaining warnings.