### PR TITLE
Update dependencies and replace deprecated itertools API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ fern = "0.7"
 serde = "1.0"
 serde_json = "1.0"
 tap = "1.0"
-slotmap = "1.0"
+slotmap = "1.1"
 float-cmp = "0.10"
-ordered-float = "5.0"
-rayon = "1.10"
-numfmt = "1.1"
+ordered-float = "5.5"
+rayon = "1.12"
+numfmt = "1.2"
 num_cpus = "1.17"
 jiff = "0.2"
 test-case = "3.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 anyhow = "1.0"
 
 getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/src/sample/best_samples.rs
+++ b/src/sample/best_samples.rs
@@ -60,7 +60,7 @@ impl BestSamples {
             debug_assert!(
                 self.samples.iter()
                     .filter(|(_, eval)| *eval != SampleEval::Invalid)
-                    .tuple_combinations().all(|(a, b)| {
+                    .array_combinations().all(|[a, b]| {
                         !dtransfs_are_similar(a.0, b.0, self.unique_thresh, self.unique_thresh)
                     }
                 ),


### PR DESCRIPTION
## Summary

- Replace deprecated `tuple_combinations` with the equivalent `array_combinations` call.
- Update the declared minimum versions of `slotmap`, `ordered-float`, `rayon`, `numfmt`, and `clap` to the versions already selected by a fresh Cargo resolution.

Sparrow does not track `Cargo.lock`, so the dependency changes update `Cargo.toml` without adding a generated lockfile.

## Verification

- Warning-free nightly all-target check with SIMD and final-SVG features.
- Stable all-target tests.
- Nightly SIMD all-target tests.
- Nightly WASM library build.
