### PR TITLE
Prepare sparrow 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparrow"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 default-run = "sparrow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "bench"
 path = "src/bench.rs"
 
 [dependencies]
-jagua-rs = { features = ["spp"], version = "0.8.0" }
+jagua-rs = { features = ["spp"], version = "0.8.1" }
 rand = "0.10"
 rand_distr = "0.6"
 svg = "0.18"

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ This optimization algorithm builds on [`jagua-rs`](https://github.com/JeroenGar/
 
 This repository accompanies the paper: ["_An open-source heuristic to reboot 2D nesting research_"](https://doi.org/10.48550/arXiv.2509.13329).
 
-## `sparrow` in action
-
-![The `sparrow` TUI dashboard running alongside the live solution viewer](data/demo.gif)
-
 > [!TIP]
 > **Try [Sparrow Studio](https://sparrowstudio.app/) in your browser.**
 >
 > Import SVG, DXF or instance JSON, configure the nesting job, watch the search live and download the result. It runs locally on your device, with no installation.
+
+## `sparrow` in action
+
+![The `sparrow` TUI dashboard running alongside the live solution viewer](data/demo.gif)
 
 ## Nested by `sparrow`
 <p align="center">
@@ -167,6 +167,7 @@ The accompanying [README](data/experiments/README.md) details how to perform an 
 
 ## Related Projects
 
+- [Sparrow Studio](https://github.com/JeroenGar/sparrow-studio): an interactive browser interface for `sparrow`
 - [`spyrrow`](https://github.com/PaulDL-RS/spyrrow): a Python wrapper of `sparrow`
 - [`sparrow-3d`](https://github.com/JonasTollenaere/sparrow-3d): a 3D adaptation of `sparrow`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This repository accompanies the paper: ["_An open-source heuristic to reboot 2D 
 ![The `sparrow` TUI dashboard running alongside the live solution viewer](data/demo.gif)
 
 > [!TIP]
-> Visit [**sparroWASM**](https://jeroengar.github.io/sparroWASM/) to see `sparrow` running in your browser!
+> **Try [Sparrow Studio](https://sparrowstudio.app/) in your browser.**
+>
+> Import SVG, DXF or instance JSON, configure the nesting job, watch the search live and download the result. It runs locally on your device, with no installation.
 
 ## Nested by `sparrow`
 <p align="center">
@@ -166,7 +168,6 @@ The accompanying [README](data/experiments/README.md) details how to perform an 
 ## Related Projects
 
 - [`spyrrow`](https://github.com/PaulDL-RS/spyrrow): a Python wrapper of `sparrow`
-- [`sparroWASM`](https://github.com/JeroenGar/sparroWASM): solve 2D nesting problems in the browser with WebAssembly
 - [`sparrow-3d`](https://github.com/JonasTollenaere/sparrow-3d): a 3D adaptation of `sparrow`
 
 ## Development

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ pub const DEFAULT_SPARROW_CONFIG: SparrowConfig = SparrowConfig {
     },
     cde_config: CDEConfig {
         quadtree_depth: 4,
-        cd_threshold: 16,
+        cd_threshold: 64,
         item_surrogate_config: SPSurrogateConfig {
             n_pole_limits: [(64, 0.0), (16, 0.8), (8, 0.9)],
             ff_pole_area_ratio: 0.5,


### PR DESCRIPTION
Prepare the package for the upcoming 0.2.0 release:

- bump the crate version to `0.2.0`;
- update `jagua-rs` to `0.8.1`;
- raise the default `jagua-rs` collision threshold from `16` to `64`, the best shared default from the 17-instance parameter sweep;
- replace the sparroWASM README links with Sparrow Studio.

The threshold remains a simple static default; no runtime autotuner or additional algorithm complexity is introduced.

## Release-wide performance check

Comparing the February `ejor-snapshot` baseline with this PR head across all 17 repository benchmark instances, exploration throughput improved on every instance. The median gain was **33.6%**, with a **32.3% geometric mean** and a range of **9.7% to 54.0%**.

These were paired 30-second, one-worker runs on Apple Silicon using nightly Rust, SIMD and `-C target-cpu=native`. An eight-instance sample using the default three workers closely reproduced the relative gains (`r = 0.981`, mean absolute difference `2.3` percentage points).

The GitHub release remains an unpublished draft until this PR lands.
