### PR TITLE
Stop search at a conservative minimum strip width

### DIFF
--- a/src/optimizer/compress.rs
+++ b/src/optimizer/compress.rs
@@ -39,14 +39,13 @@ pub fn compression_phase(
     // As long as the shrink step size is above the minimum, keep attempting to compress
     while !term.kill() && let step = shrink_step_size(n_failed_attempts) && step >= config.shrink_range.1 {
         let width = best_sol.strip_width();
-        let new_width = (width * (1.0 - step)).max(min_width);
-        let step = (width - new_width) / width;
-        if new_width >= width || step < config.shrink_range.1 {
+        let next_width = width * (1.0 - step);
+        if next_width < min_width || next_width >= width {
             info!("[CMPR] stopping at minimum strip width: {:.3}", min_width);
             break;
         }
         sol_listener.report_compression_progress(step);
-        match attempt_to_compress(sep, &best_sol, new_width, term, sol_listener) {
+        match attempt_to_compress(sep, &best_sol, step, term, sol_listener) {
             Some(compacted_sol) => {
                 info!("[CMPR] success at {:.3}% ({:.3} | {:.3}%)", step * 100.0, compacted_sol.strip_width(), compacted_sol.density(instance) * 100.0);
                 sol_listener.report(ReportType::CmprFeas, &compacted_sol, instance);
@@ -57,23 +56,19 @@ pub fn compression_phase(
                 n_failed_attempts += 1;
             }
         }
-        // ponytail: stop after one bound attempt; try intermediate widths if near-bound quality matters.
-        if new_width == min_width {
-            info!("[CMPR] finished attempt at minimum strip width: {:.3}", min_width);
-            break;
-        }
     }
     info!("[CMPR] finished, compressed from {:.3}% to {:.3}% (+{:.3}%)", init_sol.density(instance) * 100.0, best_sol.density(instance) * 100.0, (best_sol.density(instance) - init_sol.density(instance)) * 100.0);
     best_sol
 }
 
 
-fn attempt_to_compress(sep: &mut Separator, init_sol: &SPSolution, new_width: f32, term: &impl Terminator, sol_listener: &mut impl SolutionListener) -> Option<SPSolution> {
+fn attempt_to_compress(sep: &mut Separator, init_sol: &SPSolution, r_shrink: f32, term: &impl Terminator, sol_listener: &mut impl SolutionListener) -> Option<SPSolution> {
     // Restore to the initial solution and width
     sep.change_strip_width(init_sol.strip_width(), None);
     sep.rollback(init_sol, None);
 
     // Shrink the container by the provided amount at a random position
+    let new_width = init_sol.strip_width() * (1.0 - r_shrink);
     let split_pos = sep.rng.random_range(0.0..sep.prob.strip_width());
     sep.change_strip_width(new_width, Some(split_pos));
 

--- a/src/optimizer/compress.rs
+++ b/src/optimizer/compress.rs
@@ -16,6 +16,7 @@ pub fn compression_phase(
     term: &impl Terminator,
     config: &CompressionConfig
 ) -> SPSolution {
+    let min_width = super::minimum_strip_width(&sep.prob);
     let mut best_sol = init_sol.clone();
     let start = Instant::now();
     let mut n_failed_attempts = 0;
@@ -37,8 +38,15 @@ pub fn compression_phase(
 
     // As long as the shrink step size is above the minimum, keep attempting to compress
     while !term.kill() && let step = shrink_step_size(n_failed_attempts) && step >= config.shrink_range.1 {
+        let width = best_sol.strip_width();
+        let new_width = (width * (1.0 - step)).max(min_width);
+        let step = (width - new_width) / width;
+        if new_width >= width || step < config.shrink_range.1 {
+            info!("[CMPR] stopping at minimum strip width: {:.3}", min_width);
+            break;
+        }
         sol_listener.report_compression_progress(step);
-        match attempt_to_compress(sep, &best_sol, step, term, sol_listener) {
+        match attempt_to_compress(sep, &best_sol, new_width, term, sol_listener) {
             Some(compacted_sol) => {
                 info!("[CMPR] success at {:.3}% ({:.3} | {:.3}%)", step * 100.0, compacted_sol.strip_width(), compacted_sol.density(instance) * 100.0);
                 sol_listener.report(ReportType::CmprFeas, &compacted_sol, instance);
@@ -49,19 +57,23 @@ pub fn compression_phase(
                 n_failed_attempts += 1;
             }
         }
+        // ponytail: stop after one bound attempt; try intermediate widths if near-bound quality matters.
+        if new_width == min_width {
+            info!("[CMPR] finished attempt at minimum strip width: {:.3}", min_width);
+            break;
+        }
     }
     info!("[CMPR] finished, compressed from {:.3}% to {:.3}% (+{:.3}%)", init_sol.density(instance) * 100.0, best_sol.density(instance) * 100.0, (best_sol.density(instance) - init_sol.density(instance)) * 100.0);
     best_sol
 }
 
 
-fn attempt_to_compress(sep: &mut Separator, init_sol: &SPSolution, r_shrink: f32, term: &impl Terminator, sol_listener: &mut impl SolutionListener) -> Option<SPSolution> {
+fn attempt_to_compress(sep: &mut Separator, init_sol: &SPSolution, new_width: f32, term: &impl Terminator, sol_listener: &mut impl SolutionListener) -> Option<SPSolution> {
     // Restore to the initial solution and width
     sep.change_strip_width(init_sol.strip_width(), None);
     sep.rollback(init_sol, None);
 
     // Shrink the container by the provided amount at a random position
-    let new_width = init_sol.strip_width() * (1.0 - r_shrink);
     let split_pos = sep.rng.random_range(0.0..sep.prob.strip_width());
     sep.change_strip_width(new_width, Some(split_pos));
 

--- a/src/optimizer/explore.rs
+++ b/src/optimizer/explore.rs
@@ -19,6 +19,7 @@ use std::cmp::Reverse;
 
 /// Algorithm 12 from https://doi.org/10.48550/arXiv.2509.13329
 pub fn exploration_phase(instance: &SPInstance, sep: &mut Separator, sol_listener: &mut impl SolutionListener, term: &impl Terminator, config: &ExplorationConfig) -> Vec<SPSolution> {
+    let min_width = super::minimum_strip_width(&sep.prob);
     let mut current_width = sep.prob.strip_width();
     let mut best_width = current_width;
 
@@ -44,6 +45,10 @@ pub fn exploration_phase(instance: &SPInstance, sep: &mut Separator, sol_listene
             }
             // Shrink the strip width and clear the infeasible solution pool
             let next_width = current_width * (1.0 - config.shrink_step);
+            if next_width < min_width || next_width >= current_width {
+                info!("[EXPL] stopping at minimum strip width: {:.3}", min_width);
+                break;
+            }
             info!("[EXPL] shrinking strip by {}%: {:.3} -> {:.3}", config.shrink_step * 100.0, current_width, next_width);
             sep.change_strip_width(next_width, None);
             current_width = next_width;

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -6,7 +6,10 @@ use crate::optimizer::lbf::{ConstructionError, LBFBuilder};
 use crate::optimizer::separator::Separator;
 use crate::util::listener::{OptimizationPhase, ReportType, SolutionListener};
 use crate::util::terminator::Terminator;
-use jagua_rs::probs::spp::entities::{SPInstance, SPSolution};
+use jagua_rs::geometry::geo_enums::RotationRange;
+use jagua_rs::geometry::geo_traits::TransformableFrom;
+use jagua_rs::geometry::Transformation;
+use jagua_rs::probs::spp::entities::{SPInstance, SPProblem, SPSolution};
 use log::info;
 use rand::{Rng, SeedableRng};
 use std::time::Duration;
@@ -77,4 +80,36 @@ pub fn optimize(
 
     // Return the final compressed solution
     Ok(cmpr_sol)
+}
+
+/// Necessary width for the collision geometry, including the container's inset.
+/// Leave relative slack for f32 rotation and bounding-box rounding near exact fits.
+fn minimum_strip_width(prob: &SPProblem) -> f32 {
+    const REL_TOL: f32 = 1e-6;
+    let container = prob.layout.container.outer_cd.bbox;
+    let width_inset = prob.strip_width() - container.width();
+    let area: f64 = prob.instance.items.iter()
+        .map(|(item, qty)| f64::from(item.shape_cd.area) * *qty as f64)
+        .sum();
+    let mut min_width = (area / f64::from(container.height())) as f32 * (1.0 - REL_TOL);
+
+    for (item, _) in &prob.instance.items {
+        let rotations = match &item.allowed_rotation {
+            RotationRange::None => &[0.0][..],
+            RotationRange::Discrete(rotations) => rotations.as_slice(),
+            // ponytail: continuous rotations use only the area bound; add exact rotational bounds if this is too weak.
+            RotationRange::Continuous => continue,
+        };
+        let tolerance = item.shape_cd.diameter * REL_TOL;
+        let mut shape = item.shape_cd.as_ref().clone();
+        let item_width = rotations.iter()
+            .filter_map(|&rotation| {
+                let bbox = shape.transform_from(item.shape_cd.as_ref(), &Transformation::from_rotation(rotation)).bbox;
+                (bbox.height() <= container.height() + tolerance)
+                    .then_some((bbox.width() - tolerance).max(0.0))
+            })
+            .fold(f32::INFINITY, f32::min);
+        min_width = min_width.max(item_width);
+    }
+    min_width + width_inset
 }


### PR DESCRIPTION
Stop each optimization phase before its proposed shrink crosses a conservative strip-width lower bound. For #160, a 51-unit square makes the proposed 50.965-unit strip impossible; previously the search repeatedly increased collision weights while trying to resolve unavoidable exterior collisions.

Compute the bound once per phase from the collision shapes and usable container dimensions, including configured spacing. Combine total area divided by usable height with each fixed/discrete-rotation item's narrowest width among orientations that fit the height. Continuous rotations contribute only to the area bound because sampled angles cannot prove impossibility. Allow relative floating-point slack near exact fits.

Both phases use the same rule: stop if the next width is below the bound or does not reduce the current width. Exploration hands off to compression, and compression returns its best feasible solution. There is no clamping or special attempt at the bound; the existing shrink schedule and compression helper are preserved.

This deliberately stops with the best solution already found. Smaller shrink steps might still yield improvements near the bound, so early termination can leave a slightly wider result. This is not a general packing-infeasibility detector.

Validation:
- Default and SIMD `cargo test --all-targets` passed.
- WebAssembly library build passed.
- Local checks covered fixed/discrete rotations, height restrictions and exact fits, demand-weighted area, continuous-rotation fallback, spacing, both compression schedules, stopping without an attempt below the bound, and preserving the feasible solution.
- All eight seeds of the #160 job completed in 0.02–0.53 seconds with a 20-second budget, with both phases stopping before crossing the bound. All exported layouts passed feasibility checks.

Stacked on #161; the diff contains only the shrink changes. No new test files are included.

Related to #160.
